### PR TITLE
Bug Fix: Rails 7.1 Composite Primary Key Display Name Fallback

### DIFF
--- a/lib/active_admin/view_helpers/display_helper.rb
+++ b/lib/active_admin/view_helpers/display_helper.rb
@@ -7,7 +7,12 @@ module ActiveAdmin
         klass = self.class
         name = if klass.respond_to?(:model_name)
                  if klass.respond_to?(:primary_key)
-                   "#{klass.model_name.human} ##{send(klass.primary_key)}"
+                   primary_key = if klass.primary_key.is_a? Array
+                                   "(#{klass.primary_key.map { |key| "#{key}: #{send(key)}" }.join(" / ")})"
+                                 else
+                                   send(klass.primary_key)
+                                 end
+                   "#{klass.model_name.human} ##{primary_key}"
                  else
                    klass.model_name.human
                  end


### PR DESCRIPTION
This fixes an issue in Rails 7.1 where because Composite Primary Keys are supported, `primary_key` can return an array.

In this case we iterate the array and produce an output in the form:

```
Model #(key1: value1 / key2: value 2)
```

<!--

Thanks for contributing to ActiveAdmin!

You can find the instructions in our contributing guide: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md

Before submitting your PR make sure that:
* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are separated.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all CI checks are passing, but feel free to ask for early feedback if you need guidance.

[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
